### PR TITLE
added build profile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
 	// Configure Tasks
 	grunt.initConfig({
 		jshint: {
-			src: ['*.js', 'tests/*.js', 'tests/mocking/*.js', '!Gruntfile.js'],
+			src: ['*.js', 'tests/*.js', 'tests/mocking/*.js', '!Gruntfile.js', '!profile.js'],
 			options: {
 				jshintrc: '.jshintrc'
 			}

--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
 		"grunt-bower-install-simple": "0.x.x",
 		"grunt-esri-slurp": "^1.4.1",
 		"intern": ">=2.1.0"
-	}
+	},
+	"dojoBuild": "profile.js"
 }

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,12 @@
+var profile = (function(){
+    return {
+        resourceTags: {
+            test: function(filename, mid){
+                return /tests/.test(filename);
+            },
+            amd: function(filename, mid) {
+                return /ArcGISServerStore\.js$/.test(filename) && !/tests/.test(filename);
+            }
+        }
+    };
+})();


### PR DESCRIPTION
this package was failing when I tried to include it in a dojo build
the dojo build was trying to process the test files as AMD modules
I've inlcuded profile.js to tell the dojo build to stop that nonsense.

thanks to @gavinr and @kfranqueiro for help w/ this.